### PR TITLE
Avoid calling 'logging.basicConfig' at module scope.

### DIFF
--- a/src/zopyx/convert2/logger.py
+++ b/src/zopyx/convert2/logger.py
@@ -7,7 +7,4 @@
 
 import logging
 
-logging.basicConfig(level=logging.DEBUG,
-                    format='%(asctime)s %(levelname)s %(message)s')
-
-LOG = logging.getLogger('root')
+LOG = logging.getLogger('zopyx.convert2')


### PR DESCRIPTION
Configuration should happen elsewhere.  With this hardcoded line,
you'll get logs at debug level from all your packages.
